### PR TITLE
rft: Rearrange responsibility

### DIFF
--- a/base/time_source.py
+++ b/base/time_source.py
@@ -1,9 +1,13 @@
-from abc import ABCMeta, abstractmethod
-
 from base.clock_observer import ClockObserver
 
 
-class TimeSource(metaclass=ABCMeta):
-    @abstractmethod
+class TimeSource:
+    def __init__(self):
+        self.__its_observer = []
+
     def register_observer(self, observer: ClockObserver):
-        pass
+        self.__its_observer.append(observer)
+
+    def notify(self, hours: int, minutes: int, seconds: int):
+        for observer in self.__its_observer:
+            observer.update(hours, minutes, seconds)

--- a/tests/test_double/mock_time_source.py
+++ b/tests/test_double/mock_time_source.py
@@ -1,14 +1,6 @@
-from base.clock_observer import ClockObserver
 from base.time_source import TimeSource
 
 
 class MockTimeSource(TimeSource):
-    def __init__(self):
-        self.__its_observer = []
-
-    def register_observer(self, observer: ClockObserver):
-        self.__its_observer.append(observer)
-
-    def set_time(self, hours: int, minutes: int, seconds: int):
-        for observer in self.__its_observer:
-            observer.update(hours, minutes, seconds)
+    def set_time(self, hours, minutes, seconds):
+        self.notify(hours, minutes, seconds)


### PR DESCRIPTION
  - Revoke responsibility(register, update) from MockTimeSource, give it to TimeSource
  - Pull members up from MockTimeSource to TimeSource, Responsibility get more clear, and remove duplicate calls
  - Change TimeSource to Class (not Interface anymore)