### PR TITLE
rft: Delegate responsibility

### DIFF
--- a/base/time_source.py
+++ b/base/time_source.py
@@ -1,13 +1,9 @@
+from abc import ABCMeta, abstractmethod
+
 from base.clock_observer import ClockObserver
 
 
-class TimeSource:
-    def __init__(self):
-        self.__its_observer = []
-
+class TimeSource(metaclass=ABCMeta):
+    @abstractmethod
     def register_observer(self, observer: ClockObserver):
-        self.__its_observer.append(observer)
-
-    def notify(self, hours: int, minutes: int, seconds: int):
-        for observer in self.__its_observer:
-            observer.update(hours, minutes, seconds)
+        pass

--- a/tests/test_double/mock_time_source.py
+++ b/tests/test_double/mock_time_source.py
@@ -1,6 +1,15 @@
+from base.clock_observer import ClockObserver
 from base.time_source import TimeSource
+from time_source_implementation import TimeSourceImplementation
 
 
 class MockTimeSource(TimeSource):
+    def __init__(self):
+        self.__ts_imp = TimeSourceImplementation()
+
     def set_time(self, hours, minutes, seconds):
-        self.notify(hours, minutes, seconds)
+        self.__ts_imp.notify(hours, minutes, seconds)
+
+    def register_observer(self, observer: ClockObserver):
+        self.__ts_imp.register_observer(observer)
+

--- a/time_source_implementation.py
+++ b/time_source_implementation.py
@@ -1,0 +1,13 @@
+from base.clock_observer import ClockObserver
+
+
+class TimeSourceImplementation:
+    def __init__(self):
+        self.__its_observer = list()
+
+    def register_observer(self, observer: ClockObserver):
+        self.__its_observer.append(observer)
+
+    def notify(self, hours: int, minutes: int, seconds: int):
+        for observer in self.__its_observer:
+            observer.update(hours, minutes, seconds)


### PR DESCRIPTION
  - Change TimeSource to abstract base class again
  - Delegate to TimeSourceImplementation that how implement registering observer and notify to observers.
  - This commit's purpose is Child Class of MocktimeSource(ex Clock) doesn't have to know about register observer and notify to them.